### PR TITLE
Correct macro conditional on RXP_LOG_STYLING

### DIFF
--- a/include/rexo/rexo.h
+++ b/include/rexo/rexo.h
@@ -2177,7 +2177,7 @@ rxPrintTestCaseRunSummary(const struct RxTestCaseReport *pReport)
 
     passed = pReport->failureCount == 0;
 
-#ifdef RXP_LOG_STYLING
+#if RXP_LOG_STYLING
     if (isatty(fileno(stderr))) {
         rxpGetStyleAnsiCode(
             &pResultStyleStart,


### PR DESCRIPTION
This line causes preprocessor error:
https://github.com/christophercrouzet/rexo/blob/c1a146d834a5dee4e957ebd454d6818427ed2b88/include/rexo/rexo.h#L2180