### PR TITLE
Removed duplicated macro define

### DIFF
--- a/include/rexo/rexo.h
+++ b/include/rexo/rexo.h
@@ -459,7 +459,6 @@ rxRun(size_t suiteCount,
 #define RX_FREE free
 #endif /* RX_FREE */
 
-#define RXP_UNUSED(x) (void)(x)
 
 #if !defined(RX_DISABLE_LOG_STYLING) && defined(RXP_PLATFORM_UNIX)             \
     && defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 1

--- a/include/rexo/rexo.h
+++ b/include/rexo/rexo.h
@@ -459,7 +459,6 @@ rxRun(size_t suiteCount,
 #define RX_FREE free
 #endif /* RX_FREE */
 
-
 #if !defined(RX_DISABLE_LOG_STYLING) && defined(RXP_PLATFORM_UNIX)             \
     && defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 1
 #include <unistd.h>


### PR DESCRIPTION
https://github.com/christophercrouzet/rexo/blob/1f309a1c4df908b14f271fe8a082750c7d30d71e/include/rexo/rexo.h#L462
is a duplicate of line:
https://github.com/christophercrouzet/rexo/blob/1f309a1c4df908b14f271fe8a082750c7d30d71e/include/rexo/rexo.h#L47