### PR TITLE
Make a "asan for custom data sections" as on/off parameter

### DIFF
--- a/include/rexo.h
+++ b/include/rexo.h
@@ -1213,6 +1213,18 @@ rxp_test_failure_array_extend_back(struct rx_failure **slice,
     #define RXP_TEST_DISCOVERY 0
 #endif
 
+#if !defined(RXP_SANITIZE_ADDRESS)
+    #define RXP_SANITIZE_ADDRESS 1
+#endif
+
+#if !RXP_SANITIZE_ADDRESS
+    #define ATTRIBUTE(A) \
+        __attribute__((used,section(A)))
+#else
+    #define ATTRIBUTE(A) \
+        __attribute__((used,section(A),no_sanitize_address))
+#endif
+
 #if !RXP_TEST_DISCOVERY
     #define RXP_TEST_SUITE_REGISTER(NAME) RXP_REQUIRE_SEMICOLON
 #elif defined(_MSC_VER)
@@ -1244,13 +1256,13 @@ rxp_test_failure_array_extend_back(struct rx_failure **slice,
             __asm("section$end$__DATA$rxsuite");
 
         #define RXP_TEST_SUITE_SECTION                                         \
-            __attribute__((used,section("__DATA,rxsuite")))
+            ATTRIBUTE("__DATA,rxsuite")
     #else
         extern const struct rxp_test_suite_desc * const __start_rxsuite;
         extern const struct rxp_test_suite_desc * const __stop_rxsuite;
 
         #define RXP_TEST_SUITE_SECTION                                         \
-            __attribute__((used,section("rxsuite")))
+            ATTRIBUTE("rxsuite")
     #endif
 
     RXP_TEST_SUITE_SECTION
@@ -1264,18 +1276,6 @@ rxp_test_failure_array_extend_back(struct rx_failure **slice,
 
     #define RXP_TEST_SUITE_SECTION_BEGIN (&__start_rxsuite)
     #define RXP_TEST_SUITE_SECTION_END (&__stop_rxsuite)
-#endif
-
-#if !defined(RXP_SANITIZE_ADDRESS)
-    #define RXP_SANITIZE_ADDRESS 1
-#endif
-
-#if !RXP_SANITIZE_ADDRESS
-    #define ATTRIBUTE(A) \
-        __attribute__((used,section(A)))
-#else
-    #define ATTRIBUTE(A) \
-        __attribute__((used,section(A),no_sanitize_address))
 #endif
 
 #if !RXP_TEST_DISCOVERY
@@ -1309,13 +1309,13 @@ rxp_test_failure_array_extend_back(struct rx_failure **slice,
             __asm("section$end$__DATA$rxcase");
 
         #define RXP_TEST_CASE_SECTION                                          \
-            ATTRIBUTE(("__DATA,rxcase"))
+            ATTRIBUTE("__DATA,rxcase")
     #else
         extern const struct rxp_test_case_desc * const __start_rxcase;
         extern const struct rxp_test_case_desc * const __stop_rxcase;
 
         #define RXP_TEST_CASE_SECTION                                          \
-            ATTRIBUTE(("rxcase"))
+            ATTRIBUTE("rxcase")
     #endif
 
     RXP_TEST_CASE_SECTION

--- a/include/rexo.h
+++ b/include/rexo.h
@@ -1266,6 +1266,18 @@ rxp_test_failure_array_extend_back(struct rx_failure **slice,
     #define RXP_TEST_SUITE_SECTION_END (&__stop_rxsuite)
 #endif
 
+#if !defined(RXP_SANITIZE_ADDRESS)
+    #define RXP_SANITIZE_ADDRESS 1
+#endif
+
+#if !RXP_SANITIZE_ADDRESS
+    #define ATTRIBUTE(A) \
+        __attribute__((used,section(A)))
+#else
+    #define ATTRIBUTE(A) \
+        __attribute__((used,section(A),no_sanitize_address))
+#endif
+
 #if !RXP_TEST_DISCOVERY
     #define RXP_TEST_CASE_REGISTER(SUITE_NAME, NAME) RXP_REQUIRE_SEMICOLON
 #elif defined(_MSC_VER)
@@ -1297,13 +1309,13 @@ rxp_test_failure_array_extend_back(struct rx_failure **slice,
             __asm("section$end$__DATA$rxcase");
 
         #define RXP_TEST_CASE_SECTION                                          \
-            __attribute__((used,section("__DATA,rxcase")))
+            ATTRIBUTE(("__DATA,rxcase"))
     #else
         extern const struct rxp_test_case_desc * const __start_rxcase;
         extern const struct rxp_test_case_desc * const __stop_rxcase;
 
         #define RXP_TEST_CASE_SECTION                                          \
-            __attribute__((used,section("rxcase")))
+            ATTRIBUTE(("rxcase"))
     #endif
 
     RXP_TEST_CASE_SECTION

--- a/include/rexo.h
+++ b/include/rexo.h
@@ -1244,13 +1244,13 @@ rxp_test_failure_array_extend_back(struct rx_failure **slice,
             __asm("section$end$__DATA$rxsuite");
 
         #define RXP_TEST_SUITE_SECTION                                         \
-            __attribute__((used,section("__DATA,rxsuite"),no_sanitize_address))
+            __attribute__((used,section("__DATA,rxsuite")))
     #else
         extern const struct rxp_test_suite_desc * const __start_rxsuite;
         extern const struct rxp_test_suite_desc * const __stop_rxsuite;
 
         #define RXP_TEST_SUITE_SECTION                                         \
-            __attribute__((used,section("rxsuite"),no_sanitize_address))
+            __attribute__((used,section("rxsuite")))
     #endif
 
     RXP_TEST_SUITE_SECTION
@@ -1297,13 +1297,13 @@ rxp_test_failure_array_extend_back(struct rx_failure **slice,
             __asm("section$end$__DATA$rxcase");
 
         #define RXP_TEST_CASE_SECTION                                          \
-            __attribute__((used,section("__DATA,rxcase"),no_sanitize_address))
+            __attribute__((used,section("__DATA,rxcase")))
     #else
         extern const struct rxp_test_case_desc * const __start_rxcase;
         extern const struct rxp_test_case_desc * const __stop_rxcase;
 
         #define RXP_TEST_CASE_SECTION                                          \
-            __attribute__((used,section("rxcase"),no_sanitize_address))
+            __attribute__((used,section("rxcase")))
     #endif
 
     RXP_TEST_CASE_SECTION


### PR DESCRIPTION
I got a lot of warning of a parameter which is not really matters, so a propose to do make it optional for a client code and use it by default in rexo.h so your code not changed, and my code will not suffer by utilizing paramter value 0, i.e.:

```c++
#ifndef _GLOBALS_H_
#define _GLOBALS_H_

#define RXP_SANITIZE_ADDRESS 0 // just disable all no_sanitize_address warnings

#endif // _GLOBALS_H_
```

One loom share a thousands words:

https://www.loom.com/share/ab03f01d29c84bdf839cef8d17674ff4