### PR TITLE
Disable asan in data sections only for Clang

### DIFF
--- a/include/rexo.h
+++ b/include/rexo.h
@@ -1206,6 +1206,17 @@ rxp_test_failure_array_extend_back(struct rx_failure **slice,
    anything registered in these sections.
 */
 
+#if defined(__clang__)
+    /*
+       Older versions of Clang's address sanitizer incorrectly report
+       a global buffer overflow in custom data sections.
+    */
+    #define RXP_SECTION_SUPPRESS_ADDRESS_SANITIZER                             \
+        __attribute__((no_sanitize_address))
+#else
+    #define RXP_SECTION_SUPPRESS_ADDRESS_SANITIZER
+#endif
+
 #if !defined(RX_DISABLE_TEST_DISCOVERY)                                        \
     && (defined(_MSC_VER) || defined(__GNUC__) || defined(__MINGW64__))
     #define RXP_TEST_DISCOVERY 1
@@ -1244,13 +1255,15 @@ rxp_test_failure_array_extend_back(struct rx_failure **slice,
             __asm("section$end$__DATA$rxsuite");
 
         #define RXP_TEST_SUITE_SECTION                                         \
-            __attribute__((used,section("__DATA,rxsuite"),no_sanitize_address))
+            RXP_SECTION_SUPPRESS_ADDRESS_SANITIZER                             \
+            __attribute__((used,section("__DATA,rxsuite")))
     #else
         extern const struct rxp_test_suite_desc * const __start_rxsuite;
         extern const struct rxp_test_suite_desc * const __stop_rxsuite;
 
         #define RXP_TEST_SUITE_SECTION                                         \
-            __attribute__((used,section("rxsuite"),no_sanitize_address))
+            RXP_SECTION_SUPPRESS_ADDRESS_SANITIZER                             \
+            __attribute__((used,section("rxsuite")))
     #endif
 
     RXP_TEST_SUITE_SECTION
@@ -1297,13 +1310,15 @@ rxp_test_failure_array_extend_back(struct rx_failure **slice,
             __asm("section$end$__DATA$rxcase");
 
         #define RXP_TEST_CASE_SECTION                                          \
-            __attribute__((used,section("__DATA,rxcase"),no_sanitize_address))
+            RXP_SECTION_SUPPRESS_ADDRESS_SANITIZER                             \
+            __attribute__((used,section("__DATA,rxcase")))
     #else
         extern const struct rxp_test_case_desc * const __start_rxcase;
         extern const struct rxp_test_case_desc * const __stop_rxcase;
 
         #define RXP_TEST_CASE_SECTION                                          \
-            __attribute__((used,section("rxcase"),no_sanitize_address))
+            RXP_SECTION_SUPPRESS_ADDRESS_SANITIZER                             \
+            __attribute__((used,section("rxcase")))
     #endif
 
     RXP_TEST_CASE_SECTION


### PR DESCRIPTION
Some compilers like GCC don't know about the attribute `no_sanitize_address`, which is causing ton of compiler warnings.

Thanks to @default-writer for pointing this out!